### PR TITLE
Fixed mods not loading properly.

### DIFF
--- a/dayz-launcher.sh
+++ b/dayz-launcher.sh
@@ -259,17 +259,16 @@ setup_mods() {
     local modmeta="${modpath}/meta.cpp"
     [[ -f "${modmeta}" ]] || err "Missing mod metadata for: ${modid}"
 
-    local modname="$(gawk 'match($0,/name\s*=\s*"(.+)"/,m){print m[1];exit}' "${modmeta}")"
+    local modname="@$(gawk 'match($0,/name\s*=\s*"(.+)"/,m){print m[1];exit}' "${modmeta}" | sed 's/\ /_/g')"
     [[ -n "${modname}" ]] || err "Missing mod name for: ${modid}"
     debug "Mod ${modid} found: ${modname}"
-    local modlink="@$(dec2base64 "${modid}")"
 
-    if ! [[ -L "${dir_dayz}/${modlink}" ]]; then
-      msg "Creating mod symlink for: ${modname} (${modlink})"
-      ln -sr "${modpath}" "${dir_dayz}/${modlink}"
+    if ! [[ -L "${dir_dayz}/${modname}" ]]; then
+      msg "Creating mod symlink for: ${modname}"
+      ln -sr "${modpath}" "${dir_dayz}/${modname}"
     fi
 
-    MODS+=("${modlink}")
+    MODS+=("${modname}")
   done
 
   return ${missing}


### PR DESCRIPTION
I had issues joining modded servers because the mods wouldnt load correctly or would be loaded in a weird order. I believe this is because you made the mod name by converting the mod ID to base64 and using that. This made the mod unrecognisable.

I have changed it to use the mod name and replace spaces with an underscore.
So instead of loading the mods like this: `-mod=@BLDvXA;....`
It will now load them like this: `-mod=@CF;....`

I have successfully joined a modded server using this commit.